### PR TITLE
feat(flake)!: port existing configuration to flake

### DIFF
--- a/config/nixpkgs/darwin/configuration.nix
+++ b/config/nixpkgs/darwin/configuration.nix
@@ -1,8 +1,6 @@
 { config, pkgs, ... }:
 
 {
-  imports = [ ../home.nix ];
-
   environment = {
     darwinConfig = "$HOME/.config/nixpkgs/darwin/configuration.nix";
   };

--- a/config/nixpkgs/home.nix
+++ b/config/nixpkgs/home.nix
@@ -62,6 +62,7 @@
               pkgs.shfmt
               pkgs.silver-searcher
               pkgs.sshuttle
+              pkgs.statix
               pkgs.stylua
               pkgs.terraform
               pkgs.time

--- a/config/nixpkgs/home.nix
+++ b/config/nixpkgs/home.nix
@@ -51,6 +51,7 @@
               pkgs.luaPackages.luacheck
               pkgs.mkcert
               pkgs.neofetch
+              pkgs.nixpkgs-fmt
               pkgs.nodePackages.eslint
               pkgs.nodePackages.prettier
               pkgs.nodejs

--- a/config/nixpkgs/home.nix
+++ b/config/nixpkgs/home.nix
@@ -1,8 +1,6 @@
 { config, pkgs, ... }:
 
 {
-  imports = [ <home-manager/nix-darwin> ];
-
   users = {
     users = {
       veselin = {

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,7 @@
       },
       "original": {
         "owner": "lnl7",
+        "ref": "master",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -37,6 +38,7 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "master",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1673295039,
+        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1675462931,
+        "narHash": "sha256-JiOUSERBtA1lN/s9YTKGZoZ3XUicHDwr+C8swaPSh3M=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "e2c1756e3ae001ca8696912016dd31cb1503ccf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675115703,
+        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1675454231,
+        "narHash": "sha256-5rgcWq1nFWlbR3NsLqY7i/7358uhkSeMQJ/LEHk3BWA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "06999209d7a0043d4372e38f57cffae00223d592",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "darwin": "darwin",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -22,7 +22,9 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "utils": "utils"
       },
       "locked": {
@@ -40,22 +42,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1675115703,
-        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1675454231,
         "narHash": "sha256-5rgcWq1nFWlbR3NsLqY7i/7358uhkSeMQJ/LEHk3BWA=",
@@ -75,7 +61,7 @@
       "inputs": {
         "darwin": "darwin",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "A very basic flake";
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A very basic flake";
+  description = "dotfiles";
 
   inputs = {
     darwin.url = "github:lnl7/nix-darwin";

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     darwin.url = "github:lnl7/nix-darwin";
+    darwin.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { darwin, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,9 @@
     darwinConfigurations = {
       veselins-macbook-pro = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        modules = [ ];
+        modules = [
+          ./config/nixpkgs/darwin/configuration.nix
+        ];
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         ];
       };
     };
+
     formatter = {
       aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixpkgs-fmt;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     darwin.url = "github:lnl7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
     home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { darwin, home-manager, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -5,14 +5,17 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     darwin.url = "github:lnl7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager.url = "github:nix-community/home-manager";
   };
 
-  outputs = { darwin, ... }: {
+  outputs = { darwin, home-manager, ... }: {
     darwinConfigurations = {
       veselins-macbook-pro = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         modules = [
           ./config/nixpkgs/darwin/configuration.nix
+          home-manager.darwinModules.home-manager
+          ./config/nixpkgs/home.nix
         ];
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,16 @@
 {
   description = "A very basic flake";
 
-  outputs = { self, nixpkgs }: {
+  inputs = {
+    darwin.url = "github:lnl7/nix-darwin";
+  };
 
-    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
-
-    packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
-
+  outputs = { darwin, ... }: {
+    darwinConfigurations = {
+      veselins-macbook-pro = darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        modules = [ ];
+      };
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    darwin.url = "github:lnl7/nix-darwin";
+    darwin.url = "github:lnl7/nix-darwin/master";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager";
+    home-manager.url = "github:nix-community/home-manager/master";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "dotfiles";
 
   inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     darwin.url = "github:lnl7/nix-darwin";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    darwin.url = "github:lnl7/nix-darwin/master";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager/master";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    darwin = {
+      url = "github:lnl7/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { darwin, home-manager, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     };
   };
 
-  outputs = { darwin, home-manager, ... }: {
+  outputs = { nixpkgs, darwin, home-manager, ... }: {
     darwinConfigurations = {
       veselins-macbook-pro = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
@@ -25,6 +25,9 @@
           ./config/nixpkgs/home.nix
         ];
       };
+    };
+    formatter = {
+      aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixpkgs-fmt;
     };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
     darwinConfigurations = {
       veselins-macbook-pro = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
+
         modules = [
           ./config/nixpkgs/darwin/configuration.nix
           home-manager.darwinModules.home-manager

--- a/vim/ftplugin/nix.vim
+++ b/vim/ftplugin/nix.vim
@@ -1,0 +1,5 @@
+let b:ale_enabled = 1
+
+let b:ale_linters = ['statix']
+
+let b:ale_fixers = []

--- a/vim/ftplugin/nix.vim
+++ b/vim/ftplugin/nix.vim
@@ -2,4 +2,4 @@ let b:ale_enabled = 1
 
 let b:ale_linters = ['statix']
 
-let b:ale_fixers = []
+let b:ale_fixers = ['nixpkgs-fmt']


### PR DESCRIPTION
- feat(flake): init
- feat(flake): add veselins-macbook-pro to darwinConfigurations
- feat(flake): add configuration.nix to darwin modules
- feat(flake): set description to dotfiles
- feat(flake): add unstable nixpkgs to inputs
- feat(flake): set darwin nixpkgs input to follow nixpkgs
- feat(flake): add home.nix to darwin modules
- feat(flake): switch to flake
- feat(flake): set home-manager nixpkgs input to follow nixpkgs
- feat(flake): set darwin and home-manager input branch to master explicitly
- refactor(flake): join darwin and home-manager input options
- feat(home): add statix to packages
- feat(vim): add nix ftplugin with statix as linter
- feat(home): add nixpkgs-fmt to packages
- feat(vim): add nixpkgs-fmt to nix ftplugin fixers
- feat(flake): set aarch64-darwin formatter
- refactor(flake): separate formatter from darwinConfigurations
- refactor(flake): add blank line between system and modules
